### PR TITLE
Handle coded index variable sizes

### DIFF
--- a/getnetguids.py
+++ b/getnetguids.py
@@ -131,10 +131,10 @@ def get_assembly_guids(assembly_path):
 
                     # print "Which tables are sorted list: {0}".format([tilde[16:24]])
 
-                    row_counts = [0] * len(tables_present)
+                    row_counts = [0] * 64
                     t_offset = 24
                     for index in xrange(len(tables_present)):
-                        if tables_present[index]:
+                        if index < len(tables_present) and tables_present[index]:
                             row_counts[index] = struct.unpack("<I", tilde[t_offset:t_offset + 4])[0]
                             t_offset += 4
 


### PR DESCRIPTION
If a .NET assembly has a table large enough to trip a coded index into the larger 4-byte format rather than the 2-byte format, getnetguids.py would get totally thrown for a loop and read guids from somewhat arbitrary places.

is fix nao

Resolves https://github.com/CylanceSPEAR/GetNETGUIDs/issues/6

Also helps-with-but-doesn't-quite-solve https://github.com/CylanceSPEAR/GetNETGUIDs/issues/4, where there's also some strangeness at play with the `#-` metadata tables' uncompressed data, rather than the normal `#~` compressed metadata.
